### PR TITLE
Enable drag and drop of image

### DIFF
--- a/ImgOverlay/ControlPanel.xaml
+++ b/ImgOverlay/ControlPanel.xaml
@@ -6,7 +6,10 @@
         xmlns:local="clr-namespace:ImgOverlay"
         mc:Ignorable="d"
         Title="Image Overlay" Height="122.925" Width="300"
-        ResizeMode="CanMinimize">
+        ResizeMode="CanMinimize" 
+        DragOver="ControlPanel_DragOver" 
+        AllowDrop="True" 
+        Drop="ControlPanel_Drop">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition />

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -1,19 +1,7 @@
 ﻿using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Interop;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace ImgOverlay
 {
@@ -65,6 +53,36 @@ namespace ImgOverlay
         private void RotateSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             (Owner as MainWindow)?.ChangeRotation((float)e.NewValue);
+        }
+
+        private void ControlPanel_DragOver(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] s = (string[]) e.Data.GetData(DataFormats.FileDrop, false);
+                if (s.Length == 1)
+                {
+                    e.Effects = DragDropEffects.Move;
+                }
+                else
+                {
+                    e.Effects = DragDropEffects.None;
+                }
+            }
+            else
+            {
+                e.Effects = DragDropEffects.None;
+            }
+            e.Handled = true;
+        }
+
+        private void ControlPanel_Drop(object sender, DragEventArgs e)
+        {
+            string[] s = (string[])e.Data.GetData(DataFormats.FileDrop, false);
+            if (s.Length == 1)
+            {
+                (Owner as MainWindow)?.LoadImage(s[0]);
+            }
         }
     }
 }

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -32,6 +32,12 @@ namespace ImgOverlay
 
         public void LoadImage(string path)
         {
+            if (System.IO.Directory.Exists(path))
+            {
+                MessageBox.Show("Cannot open folders.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
             if (!System.IO.File.Exists(path))
             {
                 MessageBox.Show("The selected image file does not exist.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);


### PR DESCRIPTION
 This change allows you to drag and drop an image onto the `Image Overlay`  control window instead of pressing `Load`.

- Also removes unnecessary `using`'s from `ControlPanel.xaml.cs`