### PR TITLE
Improve layout of control window

### DIFF
--- a/ImgOverlay/ControlPanel.xaml
+++ b/ImgOverlay/ControlPanel.xaml
@@ -5,33 +5,144 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ImgOverlay"
         mc:Ignorable="d"
-        Title="Image Overlay" Height="122.925" Width="300"
-        ResizeMode="CanMinimize">
+        Title="Image Overlay"
+        Width="300"
+        ResizeMode="CanMinimize"
+        SizeToContent="Height">
+    <Window.Resources>
+        <Style TargetType="{x:Type ToggleButton}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ToggleButton}">
+                        <Viewbox>
+                            <Border x:Name="Border" CornerRadius="10"
+                            Background="#FFFFFFFF"
+                            Width="40" Height="20">
+                                <Border.Effect>
+                                    <DropShadowEffect ShadowDepth="0.5" Direction="0" Opacity="0.3" />
+                                </Border.Effect>
+                                <Ellipse x:Name="Ellipse" Fill="#FFFFFFFF" Stretch="Uniform"
+                                     Margin="2 1 2 1"
+                                     Stroke="Gray" StrokeThickness="0.2"
+                                     HorizontalAlignment="Stretch">
+                                    <Ellipse.Effect>
+                                        <DropShadowEffect BlurRadius="10" ShadowDepth="1" Opacity="0.3" Direction="260" />
+                                    </Ellipse.Effect>
+                                </Ellipse>
+                            </Border>
+                        </Viewbox>
+                        <ControlTemplate.Triggers>
+                            <EventTrigger RoutedEvent="Checked">
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ColorAnimation
+                                            Storyboard.TargetName="Border"
+                                            Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                            To="#FF4CD661"
+                                            Duration="0:0:0.2" />
+                                        <ThicknessAnimation
+                                            Storyboard.TargetName="Ellipse"
+                                            Storyboard.TargetProperty="Margin"
+                                            To="20 1 2 1"
+                                            Duration="0:0:0.2" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </EventTrigger>
+                            <EventTrigger RoutedEvent="Unchecked">
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ColorAnimation
+                                            Storyboard.TargetName="Border"
+                                            Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                            To="White"
+                                            Duration="0:0:0.2" />
+                                        <ThicknessAnimation
+                                            Storyboard.TargetName="Ellipse"
+                                            Storyboard.TargetProperty="Margin"
+                                            To="2 1 2 1"
+                                            Duration="0:0:0.2" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </EventTrigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <local:OnOffConverter x:Key="OnOffConverter" />
+    </Window.Resources>
     <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="50" />
             <RowDefinition />
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0">
+        <Grid Grid.Row="0" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
-            <Button x:Name="LoadButton" Grid.Column="0" Click="LoadButton_Click">
+            <Button x:Name="LoadButton" Grid.Column="0" Click="LoadButton_Click" Margin="5">
                 <TextBlock Text="Load..." />
             </Button>
-            <ToggleButton x:Name="DragButton" Grid.Column="1" Click="DragButton_Click">
-                <TextBlock Text="Move Image" />
-            </ToggleButton>
+            <Grid Grid.Column="1" Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+
+                <Label Grid.Row="0" Content="Moveable Image" VerticalAlignment="Center" Padding="0" Margin="0,0,0,3"/>
+                <StackPanel Grid.Row="1" Orientation="Horizontal">
+                    <ToggleButton x:Name="DragButton" Click="DragButton_Click" HorizontalAlignment="Left" />
+                    <Label Content="{Binding IsChecked, ElementName=DragButton, Converter={StaticResource OnOffConverter}}" VerticalAlignment="Center" Padding="0" Margin="5,0,0,0" />
+                </StackPanel>
+            </Grid>
         </Grid>
 
-        <Grid Grid.Row="1" Margin="0,0,0,16">
-            <Slider x:Name="OpacitySlider" Minimum="0" Maximum="1" Value="1" ValueChanged="OpacitySlider_ValueChanged" Margin="0,3,0,6" />
+        <Grid Grid.Row="1" Grid.ColumnSpan="2" Name="TransparencyRow" Margin="5">
+            <StackPanel>
+                <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
+                    <Label Content="Transparency: " Padding="0" />
+                    <Label Content="{Binding Value, ElementName=OpacitySlider}" Padding="0" Panel.ZIndex="-1" ContentStringFormat="{}{0:0.##}%" />
+                </StackPanel>
+                <Slider
+                    x:Name="OpacitySlider"
+                    Minimum="0"
+                    Maximum="100"
+                    Value="100"
+                    TickFrequency="1"
+                    IsSnapToTickEnabled="True"
+                    ValueChanged="OpacitySlider_ValueChanged"
+                    HorizontalAlignment="Center"
+                    Width="{Binding Path=ActualWidth, ElementName=TransparencyRow}"
+                    MouseDoubleClick="OpacitySlider_DoubleClicked" />
+            </StackPanel>
         </Grid>
-        <Grid Margin="0,22,0,16" Grid.Row="1">
-            <Slider x:Name="RotateSlider" Minimum="-180" Maximum="180" Value="0" ValueChanged="RotateSlider_ValueChanged" Margin="0,3,0,-15" />
+        <Grid Grid.Row="2" Grid.ColumnSpan="2" Name="RotationRow" Margin="5">
+            <StackPanel>
+                <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
+                    <Label Content="Rotation: " Padding="0" />
+                    <Label Content="{Binding Value, ElementName=RotateSlider}" ContentStringFormat="{}{0:0.##}°" Padding="0" Panel.ZIndex="-1" />
+                </StackPanel>
+                <Slider
+                    x:Name="RotateSlider"
+                    Minimum="-180"
+                    Maximum="180"
+                    Value="0"
+                    TickFrequency="1"
+                    IsSnapToTickEnabled="True"
+                    ValueChanged="RotateSlider_ValueChanged"
+                    Width="{Binding Path=ActualWidth, ElementName=RotationRow}"
+                    HorizontalAlignment="Center"
+                    MouseDoubleClick="RotateSlider_DoubleClicked" />
+            </StackPanel>
         </Grid>
     </Grid>
 </Window>

--- a/ImgOverlay/ControlPanel.xaml
+++ b/ImgOverlay/ControlPanel.xaml
@@ -8,7 +8,9 @@
         Title="Image Overlay"
         Width="300"
         ResizeMode="CanMinimize"
-        SizeToContent="Height">
+        SizeToContent="Height"
+        Loaded="Window_Loaded"
+>
     <Window.Resources>
         <Style TargetType="{x:Type ToggleButton}">
             <Setter Property="Template">
@@ -30,47 +32,55 @@
                                     </Ellipse.Effect>
                                 </Ellipse>
                             </Border>
+
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="MouseOver" />
+                                    <VisualState x:Name="Pressed" />
+                                    <VisualState x:Name="Disabled" />
+                                </VisualStateGroup>
+                                <VisualStateGroup x:Name="CheckStates">
+                                    <VisualState x:Name="Checked" >
+                                        <Storyboard>
+                                            <ColorAnimation
+                                                Storyboard.TargetName="Border"
+                                                Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                                To="#FF4CD661"
+                                                Duration="0:0:0.2" 
+                                            />
+                                            <ThicknessAnimation
+                                                Storyboard.TargetName="Ellipse"
+                                                Storyboard.TargetProperty="Margin"
+                                                To="20 1 2 1"
+                                                Duration="0:0:0.2" 
+                                            />
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Unchecked">
+                                        <Storyboard>
+                                            <ColorAnimation
+                                                Storyboard.TargetName="Border"
+                                                Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                                Duration="0:0:0.2" 
+                                            />
+                                            <ThicknessAnimation
+                                                Storyboard.TargetName="Ellipse"
+                                                Storyboard.TargetProperty="Margin"
+                                                Duration="0:0:0.2" 
+                                            />
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Indeterminate" />
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
                         </Viewbox>
-                        <ControlTemplate.Triggers>
-                            <EventTrigger RoutedEvent="Checked">
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <ColorAnimation
-                                            Storyboard.TargetName="Border"
-                                            Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
-                                            To="#FF4CD661"
-                                            Duration="0:0:0.2" />
-                                        <ThicknessAnimation
-                                            Storyboard.TargetName="Ellipse"
-                                            Storyboard.TargetProperty="Margin"
-                                            To="20 1 2 1"
-                                            Duration="0:0:0.2" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </EventTrigger>
-                            <EventTrigger RoutedEvent="Unchecked">
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <ColorAnimation
-                                            Storyboard.TargetName="Border"
-                                            Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
-                                            To="White"
-                                            Duration="0:0:0.2" />
-                                        <ThicknessAnimation
-                                            Storyboard.TargetName="Ellipse"
-                                            Storyboard.TargetProperty="Margin"
-                                            To="2 1 2 1"
-                                            Duration="0:0:0.2" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </EventTrigger>
-                        </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
         </Style>
 
-        <local:OnOffConverter x:Key="OnOffConverter" />
+        <local:YesNoConverter x:Key="YesNoConverter" />
     </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -98,10 +108,10 @@
                     <RowDefinition />
                 </Grid.RowDefinitions>
 
-                <Label Grid.Row="0" Content="Moveable Image" VerticalAlignment="Center" Padding="0" Margin="0,0,0,3"/>
+                <Label Grid.Row="0" Content="Movement Locked" VerticalAlignment="Center" Padding="0" Margin="0,0,0,3"/>
                 <StackPanel Grid.Row="1" Orientation="Horizontal">
                     <ToggleButton x:Name="DragButton" Click="DragButton_Click" HorizontalAlignment="Left" />
-                    <Label Content="{Binding IsChecked, ElementName=DragButton, Converter={StaticResource OnOffConverter}}" VerticalAlignment="Center" Padding="0" Margin="5,0,0,0" />
+                    <Label Content="{Binding IsChecked, ElementName=DragButton, Converter={StaticResource YesNoConverter}}" VerticalAlignment="Center" Padding="0" Margin="5,0,0,0" />
                 </StackPanel>
             </Grid>
         </Grid>

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -1,22 +1,25 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
 using System.Windows.Interop;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace ImgOverlay
 {
+    public class OnOffConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return (bool)value ? "On" : "Off";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return value.ToString() == "On";
+        }
+    }
+
     /// <summary>
     /// Interaction logic for ControlPanel.xaml
     /// </summary>
@@ -59,12 +62,22 @@ namespace ImgOverlay
 
         private void OpacitySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            (Owner as MainWindow)?.ChangeOpacity((float)e.NewValue);
+            (Owner as MainWindow)?.ChangeOpacity((float)e.NewValue / 100.0f);
+        }
+
+        private void OpacitySlider_DoubleClicked(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            OpacitySlider.SetValue(RangeBase.ValueProperty, 100.0);
         }
 
         private void RotateSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             (Owner as MainWindow)?.ChangeRotation((float)e.NewValue);
+        }
+
+        private void RotateSlider_DoubleClicked(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            RotateSlider.SetValue(RangeBase.ValueProperty, 0.0);
         }
     }
 }

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -7,16 +7,16 @@ using System.Windows.Interop;
 
 namespace ImgOverlay
 {
-    public class OnOffConverter : IValueConverter
+    public class YesNoConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return (bool)value ? "On" : "Off";
+            return (bool)value ? "Yes" : "No";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return value.ToString() == "On";
+            return value.ToString() == "Yes";
         }
     }
 
@@ -35,20 +35,30 @@ namespace ImgOverlay
             if (Owner == null)
                 return;
 
-            var opaque = (sender as ToggleButton).IsChecked.Value;
-            Owner.IsHitTestVisible = opaque;
+            var locked = (sender as ToggleButton).IsChecked.Value;
+            SetLocked(locked);
+
+            e.Handled = true;
+        }
+
+        private void SetLocked(bool locked)
+        {
+            Owner.IsHitTestVisible = !locked;
 
             var hwnd = new WindowInteropHelper(Owner).Handle;
-            if (opaque)
-            {
-                WindowsServices.SetWindowExOpaque(hwnd);
-            }
-            else
+            if (locked)
             {
                 WindowsServices.SetWindowExTransparent(hwnd);
             }
+            else
+            {
+                WindowsServices.SetWindowExOpaque(hwnd);
+            }
+        }
 
-            e.Handled = true;
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            SetLocked(DragButton.IsChecked.Value);
         }
 
         private void LoadButton_Click(object sender, RoutedEventArgs e)

--- a/ImgOverlay/MainWindow.xaml
+++ b/ImgOverlay/MainWindow.xaml
@@ -13,12 +13,13 @@
         IsHitTestVisible="False"
         Loaded="Window_Loaded"
         SourceInitialized="Window_SourceInitialized"
-        MouseDown="Window_MouseDown">
+        MouseDown="Window_MouseDown"
+        Cursor="SizeAll"
+>
     <Window.Background>
         <SolidColorBrush Opacity="0" Color="White" />
     </Window.Background>
-    <Grid >
-        <Image x:Name="DisplayImage"></Image>
-        <ResizeGrip />
+    <Grid x:Name="Container">
+        <Image x:Name="DisplayImage" />
     </Grid>
 </Window>

--- a/ImgOverlay/MainWindow.xaml
+++ b/ImgOverlay/MainWindow.xaml
@@ -10,9 +10,7 @@
         WindowStyle="None"
         AllowsTransparency="True"
         ResizeMode="CanResizeWithGrip"
-        IsHitTestVisible="False"
         Loaded="Window_Loaded"
-        SourceInitialized="Window_SourceInitialized"
         MouseDown="Window_MouseDown"
         Cursor="SizeAll"
 >

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -1,18 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace ImgOverlay
 {
@@ -21,17 +12,25 @@ namespace ImgOverlay
     /// </summary>
     public partial class MainWindow : Window
     {
-        ControlPanel cp = new ControlPanel();
+        private ControlPanel cp = new ControlPanel();
 
         public MainWindow()
         {
             Application.Current.ShutdownMode = ShutdownMode.OnMainWindowClose;
 
             InitializeComponent();
+
+            this.SizeChanged += Window_SizeChanged;
         }
 
         public void LoadImage(string path)
         {
+            if (System.IO.Directory.Exists(path))
+            {
+                MessageBox.Show("Cannot open folders.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
             if (!System.IO.File.Exists(path))
             {
                 MessageBox.Show("The selected image file does not exist.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -42,7 +41,7 @@ namespace ImgOverlay
             try
             {
                 img.BeginInit();
-                    img.UriSource = new Uri(path);
+                img.UriSource = new Uri(path);
                 img.EndInit();
             }
             catch (Exception e)
@@ -52,6 +51,7 @@ namespace ImgOverlay
             }
 
             DisplayImage.Source = img;
+            SetImageSize();
         }
 
         public void ChangeOpacity(float opacity)
@@ -72,9 +72,29 @@ namespace ImgOverlay
             TransformGroup myTransformGroup = new TransformGroup();
             myTransformGroup.Children.Add(myRotateTransform);
 
-            DisplayImage.RenderTransformOrigin = new Point(0.5, 0.5);
+            Container.RenderTransformOrigin = new Point(0.5, 0.5);
             // Associate the transforms to the button.
-            DisplayImage.RenderTransform = myTransformGroup;
+            Container.RenderTransform = myTransformGroup;
+        }
+
+        private void SetImageSize()
+        {
+            if (DisplayImage.Source != null)
+            {
+                // Set image size so that corners stay in the window when rotating
+                var w = DisplayImage.Source.Width;
+                var h = DisplayImage.Source.Height;
+                var diag = Math.Sqrt(w * w + h * h);
+
+                var scale = Math.Min(this.Width, this.Height) / diag;
+                Container.MaxWidth = w * scale;
+                Container.MaxHeight = h * scale;
+            }
+        }
+
+        private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            SetImageSize();
         }
 
         private void Window_MouseDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
Improvements to layout of control window
- Auto-fit height of window
- Labels & value readouts for transparency and rotation sliders
- Double click sliders to reset value
- Set slider interval of `1`
- Use a custom switch control instead of toggle button for image movement

Improvements to image window
- Prevent clipping of image corners when rotating
- Allow top of image window to go past the top of the screen without snapping back


**Screenshot of new layout:**
![image](https://user-images.githubusercontent.com/13784116/98501851-81a53180-22a4-11eb-8401-1d9ba5b46824.png)
