### PR TITLE
Show image actual size & hide window

### DIFF
--- a/ImgOverlay/App.config
+++ b/ImgOverlay/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ImgOverlay/ControlPanel.xaml
+++ b/ImgOverlay/ControlPanel.xaml
@@ -14,10 +14,12 @@
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition />
                 <ColumnDefinition />
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
@@ -28,12 +30,15 @@
             <ToggleButton x:Name="DragButton" Grid.Column="1" Click="DragButton_Click">
                 <TextBlock Text="Move Image" />
             </ToggleButton>
+            <Button x:Name="SizeButton" Grid.Column="2" Click="SizeButton_Click">
+                <TextBlock Text="Actual Size" />
+            </Button>
         </Grid>
 
-        <Grid Grid.Row="1" Margin="0,0,0,16">
+        <Grid Grid.Row="1" >
             <Slider x:Name="OpacitySlider" Minimum="0" Maximum="1" Value="1" ValueChanged="OpacitySlider_ValueChanged" Margin="0,3,0,6" />
         </Grid>
-        <Grid Margin="0,22,0,16" Grid.Row="1">
+        <Grid  Grid.Row="2">
             <Slider x:Name="RotateSlider" Minimum="-180" Maximum="180" Value="0" ValueChanged="RotateSlider_ValueChanged" Margin="0,3,0,-15" />
         </Grid>
     </Grid>

--- a/ImgOverlay/ControlPanel.xaml
+++ b/ImgOverlay/ControlPanel.xaml
@@ -9,7 +9,7 @@
         ResizeMode="CanMinimize" 
         DragOver="ControlPanel_DragOver" 
         AllowDrop="True" 
-        Drop="ControlPanel_Drop">
+        Drop="ControlPanel_Drop" KeyDown="Window_KeyDown">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition />

--- a/ImgOverlay/ControlPanel.xaml
+++ b/ImgOverlay/ControlPanel.xaml
@@ -22,6 +22,7 @@
                 <ColumnDefinition />
                 <ColumnDefinition />
                 <ColumnDefinition />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
             <Button x:Name="LoadButton" Grid.Column="0" Click="LoadButton_Click">
@@ -33,13 +34,16 @@
             <Button x:Name="SizeButton" Grid.Column="2" Click="SizeButton_Click">
                 <TextBlock Text="Actual Size" />
             </Button>
+            <ToggleButton x:Name="HideButton" Grid.Column="3" Click="HideButton_Click">
+                <TextBlock Text="Hide" />
+            </ToggleButton>
         </Grid>
 
         <Grid Grid.Row="1" >
-            <Slider x:Name="OpacitySlider" Minimum="0" Maximum="1" Value="1" ValueChanged="OpacitySlider_ValueChanged" Margin="0,3,0,6" />
+            <Slider x:Name="OpacitySlider" Minimum="0" Maximum="1" Value="1" ValueChanged="OpacitySlider_ValueChanged" Margin="0,6,0,0" />
         </Grid>
         <Grid  Grid.Row="2">
-            <Slider x:Name="RotateSlider" Minimum="-180" Maximum="180" Value="0" ValueChanged="RotateSlider_ValueChanged" Margin="0,3,0,-15" />
+            <Slider x:Name="RotateSlider" Minimum="-180" Maximum="180" Value="0" ValueChanged="RotateSlider_ValueChanged" Margin="0,6,0,0" />
         </Grid>
     </Grid>
 </Window>

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -123,27 +123,32 @@ namespace ImgOverlay
         {
             if ((e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.LeftCtrl) || e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.RightCtrl)) && e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.V))
             {
-                //MessageBox.Show("paste");
                 (Owner as MainWindow).LoadClipboard();
                 EnableImageControls();
-
             }
-            //e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.LeftCtrl)
-            //MessageBox.Show(e.Key.ToString());
-            //if (e.KeyChar >= 48 && e.KeyChar <= 57)
-            //{
-            //    MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' pressed.");
 
-            //    switch (e.KeyChar)
+            //if (DragButton.IsChecked.Value && DragButton.IsEnabled)
+            //{
+            //    if (e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.A)) 
             //    {
-            //        case (char)49:
-            //        case (char)52:
-            //        case (char)55:
-            //            MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' consumed.");
-            //            e.Handled = true;
-            //            break;
+            //        (Owner as MainWindow).NudgeX(-1);
             //    }
+            //    if (e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.D))
+            //    {
+            //        (Owner as MainWindow).NudgeX(1);
+            //    }
+            //    if (e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.W))
+            //    {
+            //        (Owner as MainWindow).NudgeY(-1);
+            //    }
+            //    if (e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.S))
+            //    {
+            //        (Owner as MainWindow).NudgeY(1);
+            //    }
+
             //}
+
+
         }
     }
 }

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -50,7 +50,7 @@ namespace ImgOverlay
 
         private void EnableImageControls()
         {
-            Control[] controls = { this.DragButton, this.SizeButton, this.OpacitySlider, this.RotateSlider };
+            Control[] controls = { DragButton, SizeButton, OpacitySlider, RotateSlider, HideButton };
             bool enable = false;
             if(((Owner as MainWindow)?.ImageIsLoaded).HasValue)
             {
@@ -105,6 +105,18 @@ namespace ImgOverlay
         private void SizeButton_Click(object sender, RoutedEventArgs e)
         {
             (Owner as MainWindow)?.ActualSize();
+        }
+
+
+        private void HideButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (HideButton.IsChecked.HasValue)
+            {
+                (Owner as MainWindow).Show(!HideButton.IsChecked.Value);
+            }
+
+            
+
         }
     }
 }

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -118,5 +118,32 @@ namespace ImgOverlay
             
 
         }
+
+        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if ((e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.LeftCtrl) || e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.RightCtrl)) && e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.V))
+            {
+                //MessageBox.Show("paste");
+                (Owner as MainWindow).LoadClipboard();
+                EnableImageControls();
+
+            }
+            //e.KeyboardDevice.IsKeyDown(System.Windows.Input.Key.LeftCtrl)
+            //MessageBox.Show(e.Key.ToString());
+            //if (e.KeyChar >= 48 && e.KeyChar <= 57)
+            //{
+            //    MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' pressed.");
+
+            //    switch (e.KeyChar)
+            //    {
+            //        case (char)49:
+            //        case (char)52:
+            //        case (char)55:
+            //            MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' consumed.");
+            //            e.Handled = true;
+            //            break;
+            //    }
+            //}
+        }
     }
 }

--- a/ImgOverlay/ControlPanel.xaml.cs
+++ b/ImgOverlay/ControlPanel.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Interop;
+using System.Windows.Controls;
 
 namespace ImgOverlay
 {
@@ -13,6 +14,7 @@ namespace ImgOverlay
         public ControlPanel()
         {
             InitializeComponent();
+            EnableImageControls();
         }
 
         private void DragButton_Click(object sender, RoutedEventArgs e)
@@ -42,6 +44,21 @@ namespace ImgOverlay
             if (openDialog.ShowDialog() == true)
             {
                 (Owner as MainWindow)?.LoadImage(openDialog.FileName);
+                EnableImageControls();
+            }
+        }
+
+        private void EnableImageControls()
+        {
+            Control[] controls = { this.DragButton, this.SizeButton, this.OpacitySlider, this.RotateSlider };
+            bool enable = false;
+            if(((Owner as MainWindow)?.ImageIsLoaded).HasValue)
+            {
+                enable = ((Owner as MainWindow)?.ImageIsLoaded).Value;
+            }
+            foreach (Control control in controls)
+            {
+                control.IsEnabled = enable;
             }
         }
 
@@ -83,6 +100,11 @@ namespace ImgOverlay
             {
                 (Owner as MainWindow)?.LoadImage(s[0]);
             }
+        }
+
+        private void SizeButton_Click(object sender, RoutedEventArgs e)
+        {
+            (Owner as MainWindow)?.ActualSize();
         }
     }
 }

--- a/ImgOverlay/ImgOverlay.csproj
+++ b/ImgOverlay/ImgOverlay.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>ImgOverlay</RootNamespace>
     <AssemblyName>ImgOverlay</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ImgOverlay/MainWindow.xaml
+++ b/ImgOverlay/MainWindow.xaml
@@ -13,7 +13,7 @@
         IsHitTestVisible="False"
         Loaded="Window_Loaded"
         SourceInitialized="Window_SourceInitialized"
-        MouseDown="Window_MouseDown">
+        MouseDown="Window_MouseDown" KeyDown="Window_KeyDown">
     <Window.Background>
         <SolidColorBrush Opacity="0" Color="White" />
     </Window.Background>

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -68,6 +68,18 @@ namespace ImgOverlay
             DisplayImage.Source = img;
         }
 
+        public void Show(bool visible)
+        {
+            if (visible)
+            {
+                Visibility = Visibility.Visible;
+            }
+            else
+            {
+                Visibility = Visibility.Hidden;
+            }
+        }
+
         public void ChangeOpacity(float opacity)
         {
             DisplayImage.Opacity = opacity;

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -59,7 +59,7 @@ namespace ImgOverlay
                 ImageSourceHeight = img.Height;
                 ImageSourceWidth = img.Width;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 MessageBox.Show("Error loading image. Perhaps its format is unsupported?", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -36,6 +36,17 @@ namespace ImgOverlay
             InitializeComponent();
         }
 
+        public void NudgeY(int pixels)
+        {
+            this.Top += pixels;
+
+        }
+        public void NudgeX(int pixels)
+        {
+            this.Left += pixels;
+
+        }
+
         public void LoadImage(string path)
         {
             if (System.IO.Directory.Exists(path))
@@ -179,5 +190,30 @@ namespace ImgOverlay
             var hwnd = new WindowInteropHelper(this).Handle;
             WindowsServices.SetWindowExTransparent(hwnd);
         }
+
+        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+
+                if (e.KeyboardDevice.IsKeyDown(Key.Left))
+                {
+                    NudgeX(-1);
+                }
+                if (e.KeyboardDevice.IsKeyDown(Key.Right))
+                {
+                    NudgeX(1);
+                }
+                if (e.KeyboardDevice.IsKeyDown(Key.Up))
+                {
+                    NudgeY(-1);
+                }
+                if (e.KeyboardDevice.IsKeyDown(Key.Down))
+                {
+                    NudgeY(1);
+                }
+
+
+
+        }
+
     }
 }

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -53,19 +54,63 @@ namespace ImgOverlay
             try
             {
                 img.BeginInit();
-                    img.UriSource = new Uri(path);
+                img.UriSource = new Uri(path);
                 img.EndInit();
-                ImageIsLoaded = true;
-                ImageSourceHeight = img.Height;
-                ImageSourceWidth = img.Width;
             }
             catch (Exception)
             {
-                MessageBox.Show("Error loading image. Perhaps its format is unsupported?", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show("Error loading image from storage. Perhaps its format is unsupported?", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
-            DisplayImage.Source = img;
+            ShowImage(img);
+        }
+
+        private void ShowImage(BitmapImage img)
+        {
+            try
+            {
+                DisplayImage.Source = img;
+                ImageIsLoaded = true;
+                ImageSourceHeight = img.Height;
+                ImageSourceWidth = img.Width;
+
+            }
+            catch (Exception)
+            {
+                MessageBox.Show("Error showing image. Perhaps its format is unsupported?", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        public void LoadClipboard()
+        {
+            BitmapImage bImg = new BitmapImage();
+            try
+            {
+                BitmapSource bitmapSource = Clipboard.GetImage();
+
+                PngBitmapEncoder encoder = new PngBitmapEncoder();
+                MemoryStream memoryStream = new MemoryStream();
+
+                encoder.Frames.Add(BitmapFrame.Create(bitmapSource));
+                encoder.Save(memoryStream);
+
+                memoryStream.Position = 0;
+                bImg.BeginInit();
+                bImg.StreamSource = new MemoryStream(memoryStream.ToArray());
+                bImg.EndInit();
+
+                memoryStream.Close();
+                bImg.Freeze();
+
+            }
+            catch (Exception)
+            {
+                MessageBox.Show("Error loading image from clipboard. Perhaps its format is unsupported?", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            ShowImage(bImg);
         }
 
         public void Show(bool visible)

--- a/ImgOverlay/MainWindow.xaml.cs
+++ b/ImgOverlay/MainWindow.xaml.cs
@@ -23,6 +23,11 @@ namespace ImgOverlay
     {
         ControlPanel cp = new ControlPanel();
 
+        public bool ImageIsLoaded { get; set; } = false;
+
+        public double? ImageSourceHeight { get; set; } = null;
+        public double? ImageSourceWidth { get; set; } = null;
+
         public MainWindow()
         {
             Application.Current.ShutdownMode = ShutdownMode.OnMainWindowClose;
@@ -50,6 +55,9 @@ namespace ImgOverlay
                 img.BeginInit();
                     img.UriSource = new Uri(path);
                 img.EndInit();
+                ImageIsLoaded = true;
+                ImageSourceHeight = img.Height;
+                ImageSourceWidth = img.Width;
             }
             catch (Exception e)
             {
@@ -81,6 +89,16 @@ namespace ImgOverlay
             DisplayImage.RenderTransformOrigin = new Point(0.5, 0.5);
             // Associate the transforms to the button.
             DisplayImage.RenderTransform = myTransformGroup;
+        }
+
+        public void ActualSize()
+        {
+            if (ImageSourceHeight.HasValue && ImageSourceWidth.HasValue)
+            {
+                this.Width = ImageSourceWidth.Value;
+                this.Height = ImageSourceHeight.Value;
+
+            }
         }
 
         private void Window_MouseDown(object sender, MouseButtonEventArgs e)

--- a/ImgOverlay/Properties/Resources.Designer.cs
+++ b/ImgOverlay/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace ImgOverlay.Properties
-{
-
-
+namespace ImgOverlay.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace ImgOverlay.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ImgOverlay.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/ImgOverlay/Properties/Settings.Designer.cs
+++ b/ImgOverlay/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace ImgOverlay.Properties
-{
-
-
+namespace ImgOverlay.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }


### PR DESCRIPTION
This utility would be useful to me only if I know the image is being displayed actual size. I've made the following changes:

- Add a button "Actual Size" which changes the size of MainWindow to the dimensions of the source image file.
- Controls dependent on an image having been loaded are now enabled only after an image has been loaded.
- Address issue #5 by adding a 'hide' button
- Minor visual and code cleanup.
![image](https://user-images.githubusercontent.com/302203/130334915-0c13f34c-cfd7-4537-b573-e97e1afd6944.png)
